### PR TITLE
Provide test user context when security disabled

### DIFF
--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/exception/GlobalExceptionHandler.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/exception/GlobalExceptionHandler.java
@@ -87,6 +87,19 @@ public class GlobalExceptionHandler {
     return response;
   }
 
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  @ExceptionHandler(UnauthorizedException.class)
+  public ApiResponse handleUnauthorizedException(UnauthorizedException ex) {
+    final MultiRecordErrorResponse response =
+        new MultiRecordErrorResponse(
+            HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
+
+    String message = getMessageValue(ex.getMessage(), (Object) null);
+    response.addFirstRecordDetail(EXCEPTION, message != null ? message : ex.getMessage());
+
+    return response;
+  }
+
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   @ExceptionHandler(NullPointerException.class)
   public ApiResponse handleNullPointerException(NullPointerException ex) {

--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/exception/UnauthorizedException.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.tramed.backend.core.base.exception;
+
+/** Exception thrown when a request lacks valid authentication credentials. */
+public class UnauthorizedException extends RuntimeException {
+
+  public UnauthorizedException(String message) {
+    super(message);
+  }
+}

--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/model/user/User.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/model/user/User.java
@@ -10,6 +10,12 @@ import com.tramed.backend.core.base.model.common.UserId;
  * @param passwordHash password hash stored for the user
  * @param fullName display name of the user
  * @param active status flag indicating whether the user account is active
+ * @param role the role granted to the user
  */
 public record User(
-    UserId userId, String username, String passwordHash, String fullName, boolean active) {}
+    UserId userId,
+    String username,
+    String passwordHash,
+    String fullName,
+    boolean active,
+    UserRole role) {}

--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/model/user/User.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/model/user/User.java
@@ -1,0 +1,15 @@
+package com.tramed.backend.core.base.model.user;
+
+import com.tramed.backend.core.base.model.common.UserId;
+
+/**
+ * Domain model representing an application user.
+ *
+ * @param userId unique identifier of the user
+ * @param username username used for authentication
+ * @param passwordHash password hash stored for the user
+ * @param fullName display name of the user
+ * @param active status flag indicating whether the user account is active
+ */
+public record User(
+    UserId userId, String username, String passwordHash, String fullName, boolean active) {}

--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/model/user/UserRole.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/model/user/UserRole.java
@@ -1,8 +1,6 @@
 package com.tramed.backend.core.base.model.user;
 
-/**
- * Enumerates the roles supported by the application.
- */
+/** Enumerates the roles supported by the application. */
 public enum UserRole {
   ADMIN,
   USER

--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/model/user/UserRole.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/model/user/UserRole.java
@@ -1,0 +1,9 @@
+package com.tramed.backend.core.base.model.user;
+
+/**
+ * Enumerates the roles supported by the application.
+ */
+public enum UserRole {
+  ADMIN,
+  USER
+}

--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/security/AuthenticatedUserProvider.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/security/AuthenticatedUserProvider.java
@@ -1,0 +1,17 @@
+package com.tramed.backend.core.base.security;
+
+import com.tramed.backend.core.base.model.common.UserId;
+import java.util.Optional;
+
+/**
+ * Provides access to information about the authenticated user in the current execution context.
+ */
+public interface AuthenticatedUserProvider {
+  /**
+   * Returns the identifier of the authenticated user if available.
+   *
+   * @return an {@link Optional} containing the {@link UserId} when the current request has an
+   *     authenticated user, or an empty {@link Optional} otherwise.
+   */
+  Optional<UserId> getCurrentUserId();
+}

--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/security/AuthenticatedUserProvider.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/security/AuthenticatedUserProvider.java
@@ -3,9 +3,7 @@ package com.tramed.backend.core.base.security;
 import com.tramed.backend.core.base.model.common.UserId;
 import java.util.Optional;
 
-/**
- * Provides access to information about the authenticated user in the current execution context.
- */
+/** Provides access to information about the authenticated user in the current execution context. */
 public interface AuthenticatedUserProvider {
   /**
    * Returns the identifier of the authenticated user if available.

--- a/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/security/PasswordHasher.java
+++ b/00-tramed-core/base/src/main/java/com/tramed/backend/core/base/security/PasswordHasher.java
@@ -1,0 +1,6 @@
+package com.tramed.backend.core.base.security;
+
+public interface PasswordHasher {
+
+  String encode(String rawPassword);
+}

--- a/01-tramed-presentation/web-api/build.gradle
+++ b/01-tramed-presentation/web-api/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     implementation project(':00-tramed-core:utils')
     implementation project(':02-tramed-application-core:system-core')
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     integrationTestImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/01-tramed-presentation/web-api/src/integrationTest/resources/application-test.yml
+++ b/01-tramed-presentation/web-api/src/integrationTest/resources/application-test.yml
@@ -8,3 +8,5 @@ spring:
       minimum-idle: 1
       maximum-pool-size: 5
       connection-timeout: 30000
+security:
+  test-user-id: 22222222-2222-2222-2222-222222222222

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/WebApiApplication.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/WebApiApplication.java
@@ -2,10 +2,8 @@ package com.tramed.backend.presentation.webapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication
-@ComponentScan(basePackages = "com.tramed.backend")
+@SpringBootApplication(scanBasePackages = "com.tramed.backend")
 public class WebApiApplication {
   public static void main(String[] args) {
     SpringApplication.run(WebApiApplication.class, args);

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/controller/auth/AuthenticationController.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/controller/auth/AuthenticationController.java
@@ -1,0 +1,44 @@
+package com.tramed.backend.presentation.webapi.controller.auth;
+
+import com.tramed.backend.core.base.exception.UnauthorizedException;
+import com.tramed.backend.presentation.webapi.model.auth.LoginRequest;
+import com.tramed.backend.presentation.webapi.model.auth.LoginResponse;
+import com.tramed.backend.presentation.webapi.security.jwt.JwtProperties;
+import com.tramed.backend.presentation.webapi.security.jwt.JwtTokenProvider;
+import com.tramed.backend.presentation.webapi.security.user.AdminUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tra-med-api/auth")
+public class AuthenticationController {
+
+  private final AuthenticationManager authenticationManager;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final JwtProperties jwtProperties;
+
+  @PostMapping("/login")
+  public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+    try {
+      Authentication authentication =
+          authenticationManager.authenticate(
+              new UsernamePasswordAuthenticationToken(request.username(), request.password()));
+      AdminUserDetails userDetails = (AdminUserDetails) authentication.getPrincipal();
+      String token = jwtTokenProvider.generateToken(userDetails);
+      return ResponseEntity.ok(
+          new LoginResponse(token, "Bearer", jwtProperties.expirationInMinutes()));
+    } catch (AuthenticationException ex) {
+      throw new UnauthorizedException("E0005");
+    }
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/controller/auth/AuthenticationController.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/controller/auth/AuthenticationController.java
@@ -1,18 +1,29 @@
 package com.tramed.backend.presentation.webapi.controller.auth;
 
+import com.tramed.backend.applicationcore.systemcore.service.user.RegisterUserCommand;
+import com.tramed.backend.applicationcore.systemcore.service.user.UserService;
 import com.tramed.backend.core.base.exception.UnauthorizedException;
+import com.tramed.backend.core.base.model.common.UserId;
 import com.tramed.backend.presentation.webapi.model.auth.LoginRequest;
 import com.tramed.backend.presentation.webapi.model.auth.LoginResponse;
+import com.tramed.backend.presentation.webapi.model.auth.RegisterRequest;
+import com.tramed.backend.presentation.webapi.model.auth.RegisterResponse;
+import com.tramed.backend.presentation.webapi.model.auth.UpdateUserStatusRequest;
 import com.tramed.backend.presentation.webapi.security.jwt.JwtProperties;
 import com.tramed.backend.presentation.webapi.security.jwt.JwtTokenProvider;
-import com.tramed.backend.presentation.webapi.security.user.AdminUserDetails;
+import com.tramed.backend.presentation.webapi.security.user.ApplicationUserDetails;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +37,7 @@ public class AuthenticationController {
   private final AuthenticationManager authenticationManager;
   private final JwtTokenProvider jwtTokenProvider;
   private final JwtProperties jwtProperties;
+  private final UserService userService;
 
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
@@ -33,12 +45,39 @@ public class AuthenticationController {
       Authentication authentication =
           authenticationManager.authenticate(
               new UsernamePasswordAuthenticationToken(request.username(), request.password()));
-      AdminUserDetails userDetails = (AdminUserDetails) authentication.getPrincipal();
+      ApplicationUserDetails userDetails = (ApplicationUserDetails) authentication.getPrincipal();
       String token = jwtTokenProvider.generateToken(userDetails);
       return ResponseEntity.ok(
-          new LoginResponse(token, "Bearer", jwtProperties.expirationInMinutes()));
+          new LoginResponse(
+              token,
+              "Bearer",
+              jwtProperties.expirationInMinutes(),
+              userDetails.getRole().name(),
+              userDetails.getFullName()));
     } catch (AuthenticationException ex) {
       throw new UnauthorizedException("E0005");
     }
+  }
+
+  @PostMapping("/register")
+  public ResponseEntity<RegisterResponse> register(@RequestBody @Valid RegisterRequest request) {
+    var registeredUser =
+        userService.registerUser(
+            new RegisterUserCommand(request.username(), request.password(), request.fullName()));
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(
+            new RegisterResponse(
+                registeredUser.userId().value(),
+                registeredUser.username(),
+                registeredUser.active()));
+  }
+
+  @PatchMapping("/users/{userId}/status")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Void> updateUserStatus(
+      @PathVariable UUID userId, @RequestBody @Valid UpdateUserStatusRequest request) {
+    userService.updateUserStatus(new UserId(userId), request.active());
+    return ResponseEntity.noContent().build();
   }
 }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/controller/notification/NotificationController.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/controller/notification/NotificationController.java
@@ -61,6 +61,6 @@ public class NotificationController {
       @RequestBody @Valid NotificationRequestForCreateUpdate request) {
     notificationService.insertNotification(
         Converter.convert(request, NotificationForCreateUpdate.class));
-    return new ResponseEntity<>(null, HttpStatus.CREATED);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/LoginRequest.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/LoginRequest.java
@@ -1,0 +1,6 @@
+package com.tramed.backend.presentation.webapi.model.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+    @NotBlank(message = "E0005") String username, @NotBlank(message = "E0005") String password) {}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/LoginResponse.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/LoginResponse.java
@@ -1,0 +1,3 @@
+package com.tramed.backend.presentation.webapi.model.auth;
+
+public record LoginResponse(String token, String tokenType, long expiresInMinutes) {}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/LoginResponse.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/LoginResponse.java
@@ -1,3 +1,4 @@
 package com.tramed.backend.presentation.webapi.model.auth;
 
-public record LoginResponse(String token, String tokenType, long expiresInMinutes) {}
+public record LoginResponse(
+    String token, String tokenType, long expiresInMinutes, String role, String fullName) {}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/RegisterRequest.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/RegisterRequest.java
@@ -1,0 +1,9 @@
+package com.tramed.backend.presentation.webapi.model.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+    @NotBlank @Size(min = 4, max = 100) String username,
+    @NotBlank @Size(min = 6, max = 255) String password,
+    @NotBlank @Size(max = 255) String fullName) {}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/RegisterResponse.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/RegisterResponse.java
@@ -1,0 +1,5 @@
+package com.tramed.backend.presentation.webapi.model.auth;
+
+import java.util.UUID;
+
+public record RegisterResponse(UUID userId, String username, boolean active) {}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/UpdateUserStatusRequest.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/model/auth/UpdateUserStatusRequest.java
@@ -1,0 +1,5 @@
+package com.tramed.backend.presentation.webapi.model.auth;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateUserStatusRequest(@NotNull Boolean active) {}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityAuthenticatedUserProvider.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityAuthenticatedUserProvider.java
@@ -1,0 +1,28 @@
+package com.tramed.backend.presentation.webapi.security;
+
+import com.tramed.backend.core.base.model.common.UserId;
+import com.tramed.backend.core.base.security.AuthenticatedUserProvider;
+import com.tramed.backend.presentation.webapi.security.user.AdminUserDetails;
+import java.util.Optional;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!test")
+public class SecurityAuthenticatedUserProvider implements AuthenticatedUserProvider {
+
+  @Override
+  public Optional<UserId> getCurrentUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !authentication.isAuthenticated()) {
+      return Optional.empty();
+    }
+    Object principal = authentication.getPrincipal();
+    if (principal instanceof AdminUserDetails adminUserDetails) {
+      return Optional.of(adminUserDetails.getUserId());
+    }
+    return Optional.empty();
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityAuthenticatedUserProvider.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityAuthenticatedUserProvider.java
@@ -2,7 +2,7 @@ package com.tramed.backend.presentation.webapi.security;
 
 import com.tramed.backend.core.base.model.common.UserId;
 import com.tramed.backend.core.base.security.AuthenticatedUserProvider;
-import com.tramed.backend.presentation.webapi.security.user.AdminUserDetails;
+import com.tramed.backend.presentation.webapi.security.user.ApplicationUserDetails;
 import java.util.Optional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
@@ -20,8 +20,8 @@ public class SecurityAuthenticatedUserProvider implements AuthenticatedUserProvi
       return Optional.empty();
     }
     Object principal = authentication.getPrincipal();
-    if (principal instanceof AdminUserDetails adminUserDetails) {
-      return Optional.of(adminUserDetails.getUserId());
+    if (principal instanceof ApplicationUserDetails applicationUserDetails) {
+      return Optional.of(applicationUserDetails.getUserId());
     }
     return Optional.empty();
   }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityConfig.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -44,7 +45,7 @@ public class SecurityConfig {
       JwtAuthenticationFilter jwtAuthenticationFilter,
       DaoAuthenticationProvider authenticationProvider)
       throws Exception {
-    http.csrf(csrf -> csrf.disable())
+    http.csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityConfig.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityConfig.java
@@ -1,0 +1,88 @@
+package com.tramed.backend.presentation.webapi.security;
+
+import com.tramed.backend.presentation.webapi.security.jwt.JwtAuthenticationEntryPoint;
+import com.tramed.backend.presentation.webapi.security.jwt.JwtAuthenticationFilter;
+import com.tramed.backend.presentation.webapi.security.jwt.JwtProperties;
+import com.tramed.backend.presentation.webapi.security.user.AdminUserDetailsService;
+import java.util.Arrays;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@EnableConfigurationProperties(JwtProperties.class)
+public class SecurityConfig {
+
+  private static final String[] AUTH_WHITELIST = {"/tra-med-api/auth/login"};
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final JwtAuthenticationEntryPoint authenticationEntryPoint;
+  private final AdminUserDetailsService userDetailsService;
+  private final boolean securityEnabled;
+
+  public SecurityConfig(
+      JwtAuthenticationFilter jwtAuthenticationFilter,
+      JwtAuthenticationEntryPoint authenticationEntryPoint,
+      AdminUserDetailsService userDetailsService,
+      Environment environment) {
+    this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    this.authenticationEntryPoint = authenticationEntryPoint;
+    this.userDetailsService = userDetailsService;
+    this.securityEnabled =
+        Arrays.stream(environment.getActiveProfiles())
+            .noneMatch(profile -> profile.equalsIgnoreCase("test"));
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+    if (securityEnabled) {
+      http.exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryPoint))
+          .authorizeHttpRequests(
+              auth ->
+                  auth.requestMatchers(AUTH_WHITELIST).permitAll().anyRequest().authenticated());
+      http.authenticationProvider(authenticationProvider());
+      http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    } else {
+      http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+    }
+
+    return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public DaoAuthenticationProvider authenticationProvider() {
+    DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+    provider.setUserDetailsService(userDetailsService);
+    provider.setPasswordEncoder(passwordEncoder());
+    return provider;
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+      throws Exception {
+    return configuration.getAuthenticationManager();
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityConfig.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityConfig.java
@@ -3,7 +3,7 @@ package com.tramed.backend.presentation.webapi.security;
 import com.tramed.backend.presentation.webapi.security.jwt.JwtAuthenticationEntryPoint;
 import com.tramed.backend.presentation.webapi.security.jwt.JwtAuthenticationFilter;
 import com.tramed.backend.presentation.webapi.security.jwt.JwtProperties;
-import com.tramed.backend.presentation.webapi.security.user.AdminUserDetailsService;
+import com.tramed.backend.presentation.webapi.security.user.ApplicationUserDetailsService;
 import java.util.Arrays;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -27,17 +27,19 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
 
-  private static final String[] AUTH_WHITELIST = {"/tra-med-api/auth/login"};
+  private static final String[] AUTH_WHITELIST = {
+    "/tra-med-api/auth/login", "/tra-med-api/auth/register"
+  };
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
   private final JwtAuthenticationEntryPoint authenticationEntryPoint;
-  private final AdminUserDetailsService userDetailsService;
+  private final ApplicationUserDetailsService userDetailsService;
   private final boolean securityEnabled;
 
   public SecurityConfig(
       JwtAuthenticationFilter jwtAuthenticationFilter,
       JwtAuthenticationEntryPoint authenticationEntryPoint,
-      AdminUserDetailsService userDetailsService,
+      ApplicationUserDetailsService userDetailsService,
       Environment environment) {
     this.jwtAuthenticationFilter = jwtAuthenticationFilter;
     this.authenticationEntryPoint = authenticationEntryPoint;

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityConfig.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SecurityConfig.java
@@ -31,36 +31,29 @@ public class SecurityConfig {
     "/tra-med-api/auth/login", "/tra-med-api/auth/register"
   };
 
-  private final JwtAuthenticationFilter jwtAuthenticationFilter;
-  private final JwtAuthenticationEntryPoint authenticationEntryPoint;
-  private final ApplicationUserDetailsService userDetailsService;
-  private final boolean securityEnabled;
+  private final Environment environment;
 
-  public SecurityConfig(
-      JwtAuthenticationFilter jwtAuthenticationFilter,
-      JwtAuthenticationEntryPoint authenticationEntryPoint,
-      ApplicationUserDetailsService userDetailsService,
-      Environment environment) {
-    this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-    this.authenticationEntryPoint = authenticationEntryPoint;
-    this.userDetailsService = userDetailsService;
-    this.securityEnabled =
-        Arrays.stream(environment.getActiveProfiles())
-            .noneMatch(profile -> profile.equalsIgnoreCase("test"));
+  public SecurityConfig(Environment environment) {
+    this.environment = environment;
   }
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain securityFilterChain(
+      HttpSecurity http,
+      JwtAuthenticationEntryPoint authenticationEntryPoint,
+      JwtAuthenticationFilter jwtAuthenticationFilter,
+      DaoAuthenticationProvider authenticationProvider)
+      throws Exception {
     http.csrf(csrf -> csrf.disable())
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-    if (securityEnabled) {
+    if (securityEnabled()) {
       http.exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryPoint))
           .authorizeHttpRequests(
               auth ->
                   auth.requestMatchers(AUTH_WHITELIST).permitAll().anyRequest().authenticated());
-      http.authenticationProvider(authenticationProvider());
+      http.authenticationProvider(authenticationProvider);
       http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
     } else {
       http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
@@ -75,10 +68,11 @@ public class SecurityConfig {
   }
 
   @Bean
-  public DaoAuthenticationProvider authenticationProvider() {
+  public DaoAuthenticationProvider authenticationProvider(
+      ApplicationUserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
     DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
     provider.setUserDetailsService(userDetailsService);
-    provider.setPasswordEncoder(passwordEncoder());
+    provider.setPasswordEncoder(passwordEncoder);
     return provider;
   }
 
@@ -86,5 +80,10 @@ public class SecurityConfig {
   public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
       throws Exception {
     return configuration.getAuthenticationManager();
+  }
+
+  private boolean securityEnabled() {
+    return Arrays.stream(environment.getActiveProfiles())
+        .noneMatch(profile -> profile.equalsIgnoreCase("test"));
   }
 }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SpringPasswordHasher.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/SpringPasswordHasher.java
@@ -1,0 +1,18 @@
+package com.tramed.backend.presentation.webapi.security;
+
+import com.tramed.backend.core.base.security.PasswordHasher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SpringPasswordHasher implements PasswordHasher {
+
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  public String encode(String rawPassword) {
+    return passwordEncoder.encode(rawPassword);
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/TestSecurityAuthenticatedUserProvider.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/TestSecurityAuthenticatedUserProvider.java
@@ -1,0 +1,26 @@
+package com.tramed.backend.presentation.webapi.security;
+
+import com.tramed.backend.core.base.model.common.UserId;
+import com.tramed.backend.core.base.security.AuthenticatedUserProvider;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("test")
+public class TestSecurityAuthenticatedUserProvider implements AuthenticatedUserProvider {
+
+  private final UserId testUserId;
+
+  public TestSecurityAuthenticatedUserProvider(
+      @Value("${security.test-user-id:22222222-2222-2222-2222-222222222222}") UUID testUserId) {
+    this.testUserId = new UserId(testUserId);
+  }
+
+  @Override
+  public Optional<UserId> getCurrentUserId() {
+    return Optional.of(testUserId);
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.tramed.backend.presentation.webapi.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+  public JwtAuthenticationEntryPoint(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException, ServletException {
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("status", HttpStatus.UNAUTHORIZED.value());
+    body.put("error", HttpStatus.UNAUTHORIZED.getReasonPhrase());
+    body.put("message", authException.getMessage());
+    body.put("path", request.getRequestURI());
+
+    objectMapper.writeValue(response.getOutputStream(), body);
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,6 @@
 package com.tramed.backend.presentation.webapi.security.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -27,7 +26,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
       HttpServletRequest request,
       HttpServletResponse response,
       AuthenticationException authException)
-      throws IOException, ServletException {
+      throws IOException {
     response.setStatus(HttpStatus.UNAUTHORIZED.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(
-          @NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain filterChain)
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      FilterChain filterChain)
       throws ServletException, IOException {
     extractToken(request)
         .ifPresent(

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
 import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -30,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(
-      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+          @NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     extractToken(request)
         .ifPresent(

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.tramed.backend.presentation.webapi.security.jwt;
+
+import com.tramed.backend.presentation.webapi.security.user.AdminUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  private final JwtTokenProvider tokenProvider;
+  private final AdminUserDetailsService userDetailsService;
+
+  public JwtAuthenticationFilter(
+      JwtTokenProvider tokenProvider, AdminUserDetailsService userDetailsService) {
+    this.tokenProvider = tokenProvider;
+    this.userDetailsService = userDetailsService;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    extractToken(request)
+        .ifPresent(
+            token -> {
+              if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                String username = tokenProvider.getUsernameFromToken(token);
+                try {
+                  var userDetails = userDetailsService.loadActiveUser(username);
+                  if (tokenProvider.validateToken(token, userDetails)) {
+                    UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                  }
+                } catch (RuntimeException ex) {
+                  SecurityContextHolder.clearContext();
+                }
+              }
+            });
+
+    filterChain.doFilter(request, response);
+  }
+
+  private Optional<String> extractToken(HttpServletRequest request) {
+    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (header != null && header.startsWith(BEARER_PREFIX)) {
+      return Optional.of(header.substring(BEARER_PREFIX.length()));
+    }
+    return Optional.empty();
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.tramed.backend.presentation.webapi.security.jwt;
 
-import com.tramed.backend.presentation.webapi.security.user.AdminUserDetailsService;
+import com.tramed.backend.presentation.webapi.security.user.ApplicationUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,10 +20,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private static final String BEARER_PREFIX = "Bearer ";
 
   private final JwtTokenProvider tokenProvider;
-  private final AdminUserDetailsService userDetailsService;
+  private final ApplicationUserDetailsService userDetailsService;
 
   public JwtAuthenticationFilter(
-      JwtTokenProvider tokenProvider, AdminUserDetailsService userDetailsService) {
+      JwtTokenProvider tokenProvider, ApplicationUserDetailsService userDetailsService) {
     this.tokenProvider = tokenProvider;
     this.userDetailsService = userDetailsService;
   }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
@@ -36,8 +36,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         .ifPresent(
             token -> {
               if (SecurityContextHolder.getContext().getAuthentication() == null) {
-                String username = tokenProvider.getUsernameFromToken(token);
                 try {
+                  String username = tokenProvider.getUsernameFromToken(token);
                   var userDetails = userDetailsService.loadActiveUser(username);
                   if (tokenProvider.validateToken(token, userDetails)) {
                     UsernamePasswordAuthenticationToken authentication =

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtProperties.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtProperties.java
@@ -1,0 +1,6 @@
+package com.tramed.backend.presentation.webapi.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.security.jwt")
+public record JwtProperties(String secret, long expirationInMinutes) {}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenProvider.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,60 @@
+package com.tramed.backend.presentation.webapi.security.jwt;
+
+import com.tramed.backend.presentation.webapi.security.user.AdminUserDetails;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+  private final JwtProperties properties;
+  private final Key signingKey;
+
+  public JwtTokenProvider(JwtProperties properties) {
+    this.properties = properties;
+    if (properties.secret() == null || properties.secret().isBlank()) {
+      throw new IllegalStateException("JWT secret must be configured");
+    }
+    if (properties.expirationInMinutes() <= 0) {
+      throw new IllegalStateException("JWT expiration must be a positive value");
+    }
+    this.signingKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(properties.secret()));
+  }
+
+  public String generateToken(AdminUserDetails userDetails) {
+    Instant now = Instant.now();
+    Instant expiry = now.plus(properties.expirationInMinutes(), ChronoUnit.MINUTES);
+
+    return Jwts.builder()
+        .setSubject(userDetails.getUsername())
+        .claim("uid", userDetails.getUserId().value().toString())
+        .setIssuedAt(Date.from(now))
+        .setExpiration(Date.from(expiry))
+        .signWith(signingKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public String getUsernameFromToken(String token) {
+    return parseClaims(token).getSubject();
+  }
+
+  public boolean validateToken(String token, UserDetails userDetails) {
+    Claims claims = parseClaims(token);
+    String username = claims.getSubject();
+    Date expiration = claims.getExpiration();
+    return username.equals(userDetails.getUsername()) && expiration.after(new Date());
+  }
+
+  private Claims parseClaims(String token) {
+    return Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token).getPayload();
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenProvider.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenProvider.java
@@ -1,6 +1,6 @@
 package com.tramed.backend.presentation.webapi.security.jwt;
 
-import com.tramed.backend.presentation.webapi.security.user.AdminUserDetails;
+import com.tramed.backend.presentation.webapi.security.user.ApplicationUserDetails;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -30,13 +30,14 @@ public class JwtTokenProvider {
     this.signingKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(properties.secret()));
   }
 
-  public String generateToken(AdminUserDetails userDetails) {
+  public String generateToken(ApplicationUserDetails userDetails) {
     Instant now = Instant.now();
     Instant expiry = now.plus(properties.expirationInMinutes(), ChronoUnit.MINUTES);
 
     return Jwts.builder()
         .setSubject(userDetails.getUsername())
         .claim("uid", userDetails.getUserId().value().toString())
+        .claim("role", userDetails.getRole().name())
         .setIssuedAt(Date.from(now))
         .setExpiration(Date.from(expiry))
         .signWith(signingKey, SignatureAlgorithm.HS256)

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenProvider.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenProvider.java
@@ -56,6 +56,6 @@ public class JwtTokenProvider {
   }
 
   private Claims parseClaims(String token) {
-    return Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token).getPayload();
+    return Jwts.parserBuilder().setSigningKey(signingKey).build().parseClaimsJws(token).getBody();
   }
 }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/AdminUserDetails.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/AdminUserDetails.java
@@ -1,0 +1,60 @@
+package com.tramed.backend.presentation.webapi.security.user;
+
+import com.tramed.backend.core.base.model.common.UserId;
+import com.tramed.backend.core.base.model.user.User;
+import java.util.Collection;
+import java.util.Collections;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class AdminUserDetails implements UserDetails {
+
+  private final User user;
+
+  public AdminUserDetails(User user) {
+    this.user = user;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String getPassword() {
+    return user.passwordHash();
+  }
+
+  @Override
+  public String getUsername() {
+    return user.username();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return user.active();
+  }
+
+  public UserId getUserId() {
+    return user.userId();
+  }
+
+  public String getFullName() {
+    return user.fullName();
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/AdminUserDetailsService.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/AdminUserDetailsService.java
@@ -1,0 +1,34 @@
+package com.tramed.backend.presentation.webapi.security.user;
+
+import com.tramed.backend.applicationcore.systemcore.service.user.UserService;
+import com.tramed.backend.core.base.exception.UnauthorizedException;
+import com.tramed.backend.core.base.model.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserDetailsService implements UserDetailsService {
+
+  private final UserService userService;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    return userService
+        .findByUsername(username)
+        .filter(User::active)
+        .map(AdminUserDetails::new)
+        .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+  }
+
+  public AdminUserDetails loadActiveUser(String username) {
+    return userService
+        .findByUsername(username)
+        .filter(User::active)
+        .map(AdminUserDetails::new)
+        .orElseThrow(() -> new UnauthorizedException("E0005"));
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/ApplicationUserDetails.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/ApplicationUserDetails.java
@@ -2,22 +2,24 @@ package com.tramed.backend.presentation.webapi.security.user;
 
 import com.tramed.backend.core.base.model.common.UserId;
 import com.tramed.backend.core.base.model.user.User;
+import com.tramed.backend.core.base.model.user.UserRole;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-public class AdminUserDetails implements UserDetails {
+public class ApplicationUserDetails implements UserDetails {
 
   private final User user;
 
-  public AdminUserDetails(User user) {
+  public ApplicationUserDetails(User user) {
     this.user = user;
   }
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return Collections.emptyList();
+    return List.of(new SimpleGrantedAuthority("ROLE_" + user.role().name()));
   }
 
   @Override
@@ -56,5 +58,9 @@ public class AdminUserDetails implements UserDetails {
 
   public String getFullName() {
     return user.fullName();
+  }
+
+  public UserRole getRole() {
+    return user.role();
   }
 }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/ApplicationUserDetails.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/ApplicationUserDetails.java
@@ -11,35 +11,35 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 public record ApplicationUserDetails(User user) implements UserDetails {
 
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + user.role().name()));
-    }
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(new SimpleGrantedAuthority("ROLE_" + user.role().name()));
+  }
 
-    @Override
-    public String getPassword() {
-        return user.passwordHash();
-    }
+  @Override
+  public String getPassword() {
+    return user.passwordHash();
+  }
 
-    @Override
-    public String getUsername() {
-        return user.username();
-    }
+  @Override
+  public String getUsername() {
+    return user.username();
+  }
 
-    @Override
-    public boolean isEnabled() {
-        return user.active();
-    }
+  @Override
+  public boolean isEnabled() {
+    return user.active();
+  }
 
-    public UserId getUserId() {
-        return user.userId();
-    }
+  public UserId getUserId() {
+    return user.userId();
+  }
 
-    public String getFullName() {
-        return user.fullName();
-    }
+  public String getFullName() {
+    return user.fullName();
+  }
 
-    public UserRole getRole() {
-        return user.role();
-    }
+  public UserRole getRole() {
+    return user.role();
+  }
 }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/ApplicationUserDetails.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/ApplicationUserDetails.java
@@ -9,58 +9,37 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-public class ApplicationUserDetails implements UserDetails {
+public record ApplicationUserDetails(User user) implements UserDetails {
 
-  private final User user;
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.role().name()));
+    }
 
-  public ApplicationUserDetails(User user) {
-    this.user = user;
-  }
+    @Override
+    public String getPassword() {
+        return user.passwordHash();
+    }
 
-  @Override
-  public Collection<? extends GrantedAuthority> getAuthorities() {
-    return List.of(new SimpleGrantedAuthority("ROLE_" + user.role().name()));
-  }
+    @Override
+    public String getUsername() {
+        return user.username();
+    }
 
-  @Override
-  public String getPassword() {
-    return user.passwordHash();
-  }
+    @Override
+    public boolean isEnabled() {
+        return user.active();
+    }
 
-  @Override
-  public String getUsername() {
-    return user.username();
-  }
+    public UserId getUserId() {
+        return user.userId();
+    }
 
-  @Override
-  public boolean isAccountNonExpired() {
-    return true;
-  }
+    public String getFullName() {
+        return user.fullName();
+    }
 
-  @Override
-  public boolean isAccountNonLocked() {
-    return true;
-  }
-
-  @Override
-  public boolean isCredentialsNonExpired() {
-    return true;
-  }
-
-  @Override
-  public boolean isEnabled() {
-    return user.active();
-  }
-
-  public UserId getUserId() {
-    return user.userId();
-  }
-
-  public String getFullName() {
-    return user.fullName();
-  }
-
-  public UserRole getRole() {
-    return user.role();
-  }
+    public UserRole getRole() {
+        return user.role();
+    }
 }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/ApplicationUserDetailsService.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/user/ApplicationUserDetailsService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class AdminUserDetailsService implements UserDetailsService {
+public class ApplicationUserDetailsService implements UserDetailsService {
 
   private final UserService userService;
 
@@ -20,15 +20,15 @@ public class AdminUserDetailsService implements UserDetailsService {
     return userService
         .findByUsername(username)
         .filter(User::active)
-        .map(AdminUserDetails::new)
+        .map(ApplicationUserDetails::new)
         .orElseThrow(() -> new UsernameNotFoundException("User not found"));
   }
 
-  public AdminUserDetails loadActiveUser(String username) {
+  public ApplicationUserDetails loadActiveUser(String username) {
     return userService
         .findByUsername(username)
         .filter(User::active)
-        .map(AdminUserDetails::new)
+        .map(ApplicationUserDetails::new)
         .orElseThrow(() -> new UnauthorizedException("E0005"));
   }
 }

--- a/01-tramed-presentation/web-api/src/main/resources/application.properties
+++ b/01-tramed-presentation/web-api/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+app.security.jwt.secret=VGhhbmhuYWRtaW5KV1RTZWNyZXRLRXkxMjM0NTY3ODkwMTIzNA==
+app.security.jwt.expiration-in-minutes=60

--- a/01-tramed-presentation/web-api/src/main/resources/messages.properties
+++ b/01-tramed-presentation/web-api/src/main/resources/messages.properties
@@ -3,3 +3,5 @@ E0002=The locale is a required field
 E0003=The notificationID is an invalid UUID
 E0004=User is not authenticated
 E0005=Invalid username or password
+E0006=Username already exists
+E0007=User does not exist

--- a/01-tramed-presentation/web-api/src/main/resources/messages.properties
+++ b/01-tramed-presentation/web-api/src/main/resources/messages.properties
@@ -1,3 +1,5 @@
 E0001=The content of notification must be less than or equal to 255 characters
 E0002=The locale is a required field
 E0003=The notificationID is an invalid UUID
+E0004=User is not authenticated
+E0005=Invalid username or password

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/BaseService.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/BaseService.java
@@ -1,0 +1,18 @@
+package com.tramed.backend.applicationcore.systemcore.service;
+
+import com.tramed.backend.core.base.exception.UnauthorizedException;
+import com.tramed.backend.core.base.model.common.UserId;
+import com.tramed.backend.core.base.security.AuthenticatedUserProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public abstract class BaseService {
+
+  private final AuthenticatedUserProvider authenticatedUserProvider;
+
+  protected UserId requireCurrentUserId() {
+    return authenticatedUserProvider
+        .getCurrentUserId()
+        .orElseThrow(() -> new UnauthorizedException("E0004"));
+  }
+}

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/notification/NotificationService.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/notification/NotificationService.java
@@ -11,21 +11,27 @@ import com.tramed.backend.core.base.model.notification.NotificationId;
 import com.tramed.backend.core.base.model.notification.NotificationQueryResult;
 import com.tramed.backend.core.base.pagination.PageModel;
 import com.tramed.backend.core.base.pagination.PageRequest;
+import com.tramed.backend.applicationcore.systemcore.service.BaseService;
+import com.tramed.backend.core.base.security.AuthenticatedUserProvider;
 import com.tramed.backend.infrastructure.mybatis.entity.notification.NotificationContentEntity;
 import com.tramed.backend.infrastructure.mybatis.entity.notification.NotificationEntity;
 import com.tramed.backend.infrastructure.mybatis.repository.NotificationContentRepository;
 import java.time.Instant;
 import java.util.List;
-import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
-public class NotificationService {
+public class NotificationService extends BaseService {
 
   private final NotificationContentRepository notificationContentRepository;
+
+  public NotificationService(
+      NotificationContentRepository notificationContentRepository,
+      AuthenticatedUserProvider authenticatedUserProvider) {
+    super(authenticatedUserProvider);
+    this.notificationContentRepository = notificationContentRepository;
+  }
 
   /**
    * Fetch list of notification with locale VN
@@ -55,8 +61,7 @@ public class NotificationService {
    */
   @Transactional
   public void insertNotification(NotificationForCreateUpdate notificationForCreateUpdate) {
-    // Hard code userId, update later when implement spring security
-    UserId userId = new UserId(UUID.fromString("22222222-2222-2222-2222-222222222222"));
+    UserId userId = requireCurrentUserId();
     Locale locale = notificationForCreateUpdate.locale();
     NotificationId notificationId = notificationForCreateUpdate.notificationId();
     if (notificationId == null) {

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/notification/NotificationService.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/notification/NotificationService.java
@@ -1,6 +1,7 @@
 package com.tramed.backend.applicationcore.systemcore.service.notification;
 
 import com.fasterxml.uuid.Generators;
+import com.tramed.backend.applicationcore.systemcore.service.BaseService;
 import com.tramed.backend.core.base.exception.NotFoundResourceException;
 import com.tramed.backend.core.base.exception.PreconditionException;
 import com.tramed.backend.core.base.model.common.Locale;
@@ -11,7 +12,6 @@ import com.tramed.backend.core.base.model.notification.NotificationId;
 import com.tramed.backend.core.base.model.notification.NotificationQueryResult;
 import com.tramed.backend.core.base.pagination.PageModel;
 import com.tramed.backend.core.base.pagination.PageRequest;
-import com.tramed.backend.applicationcore.systemcore.service.BaseService;
 import com.tramed.backend.core.base.security.AuthenticatedUserProvider;
 import com.tramed.backend.infrastructure.mybatis.entity.notification.NotificationContentEntity;
 import com.tramed.backend.infrastructure.mybatis.entity.notification.NotificationEntity;

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/RegisterUserCommand.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/RegisterUserCommand.java
@@ -1,6 +1,4 @@
 package com.tramed.backend.applicationcore.systemcore.service.user;
 
-/**
- * Command object used to register a new user.
- */
+/** Command object used to register a new user. */
 public record RegisterUserCommand(String username, String password, String fullName) {}

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/RegisterUserCommand.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/RegisterUserCommand.java
@@ -1,0 +1,6 @@
+package com.tramed.backend.applicationcore.systemcore.service.user;
+
+/**
+ * Command object used to register a new user.
+ */
+public record RegisterUserCommand(String username, String password, String fullName) {}

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/UserService.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/UserService.java
@@ -6,10 +6,10 @@ import com.tramed.backend.core.base.exception.PreconditionException;
 import com.tramed.backend.core.base.model.common.UserId;
 import com.tramed.backend.core.base.model.user.User;
 import com.tramed.backend.core.base.model.user.UserRole;
+import com.tramed.backend.core.base.security.PasswordHasher;
 import com.tramed.backend.infrastructure.mybatis.repository.UserRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
-  private final PasswordEncoder passwordEncoder;
+  private final PasswordHasher passwordHasher;
 
   public Optional<User> findByUsername(String username) {
     return userRepository.findByUsername(username);
@@ -42,7 +42,7 @@ public class UserService {
         new User(
             userId,
             command.username(),
-            passwordEncoder.encode(command.password()),
+            passwordHasher.encode(command.password()),
             command.fullName(),
             false,
             UserRole.USER);

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/UserService.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/UserService.java
@@ -1,0 +1,18 @@
+package com.tramed.backend.applicationcore.systemcore.service.user;
+
+import com.tramed.backend.core.base.model.user.User;
+import com.tramed.backend.infrastructure.mybatis.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  public Optional<User> findByUsername(String username) {
+    return userRepository.findByUsername(username);
+  }
+}

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/UserService.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/UserService.java
@@ -1,18 +1,67 @@
 package com.tramed.backend.applicationcore.systemcore.service.user;
 
+import com.fasterxml.uuid.Generators;
+import com.tramed.backend.core.base.exception.NotFoundResourceException;
+import com.tramed.backend.core.base.exception.PreconditionException;
+import com.tramed.backend.core.base.model.common.UserId;
 import com.tramed.backend.core.base.model.user.User;
+import com.tramed.backend.core.base.model.user.UserRole;
 import com.tramed.backend.infrastructure.mybatis.repository.UserRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
   private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
 
   public Optional<User> findByUsername(String username) {
     return userRepository.findByUsername(username);
+  }
+
+  public Optional<User> findById(UserId userId) {
+    return userRepository.findById(userId);
+  }
+
+  @Transactional
+  public User registerUser(RegisterUserCommand command) {
+    userRepository
+        .findByUsername(command.username())
+        .ifPresent(
+            user -> {
+              throw new PreconditionException("E0006");
+            });
+
+    UserId userId = new UserId(Generators.timeBasedEpochGenerator().generate());
+    User user =
+        new User(
+            userId,
+            command.username(),
+            passwordEncoder.encode(command.password()),
+            command.fullName(),
+            false,
+            UserRole.USER);
+
+    userRepository.insert(user);
+    return user;
+  }
+
+  @Transactional
+  public User updateUserStatus(UserId userId, boolean active) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new NotFoundResourceException("E0007"));
+
+    User updatedUser =
+        new User(
+            user.userId(), user.username(), user.passwordHash(), user.fullName(), active, user.role());
+    userRepository.updateStatus(userId, active);
+    return updatedUser;
   }
 }

--- a/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/UserService.java
+++ b/02-tramed-application-core/system-core/src/main/java/com/tramed/backend/applicationcore/systemcore/service/user/UserService.java
@@ -54,13 +54,16 @@ public class UserService {
   @Transactional
   public User updateUserStatus(UserId userId, boolean active) {
     User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new NotFoundResourceException("E0007"));
+        userRepository.findById(userId).orElseThrow(() -> new NotFoundResourceException("E0007"));
 
     User updatedUser =
         new User(
-            user.userId(), user.username(), user.passwordHash(), user.fullName(), active, user.role());
+            user.userId(),
+            user.username(),
+            user.passwordHash(),
+            user.fullName(),
+            active,
+            user.role());
     userRepository.updateStatus(userId, active);
     return updatedUser;
   }

--- a/02-tramed-application-core/system-core/src/test/java/com/tramed/backend/applicationcore/systemcore/service/notification/NotificationServiceTest.java
+++ b/02-tramed-application-core/system-core/src/test/java/com/tramed/backend/applicationcore/systemcore/service/notification/NotificationServiceTest.java
@@ -2,6 +2,7 @@ package com.tramed.backend.applicationcore.systemcore.service.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,11 +17,13 @@ import com.tramed.backend.core.base.model.notification.NotificationId;
 import com.tramed.backend.core.base.model.notification.NotificationQueryResult;
 import com.tramed.backend.core.base.pagination.PageModel;
 import com.tramed.backend.core.base.pagination.PageRequest;
+import com.tramed.backend.core.base.security.AuthenticatedUserProvider;
 import com.tramed.backend.infrastructure.mybatis.entity.notification.NotificationContentEntity;
 import com.tramed.backend.infrastructure.mybatis.entity.notification.NotificationEntity;
 import com.tramed.backend.infrastructure.mybatis.repository.NotificationContentRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,12 +36,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class NotificationServiceTest {
 
   @Mock private NotificationContentRepository notificationContentRepository;
+  @Mock private AuthenticatedUserProvider authenticatedUserProvider;
 
   private NotificationService notificationService;
 
   @BeforeEach
   void setUp() {
-    notificationService = new NotificationService(notificationContentRepository);
+    notificationService =
+        new NotificationService(notificationContentRepository, authenticatedUserProvider);
+    lenient()
+        .when(authenticatedUserProvider.getCurrentUserId())
+        .thenReturn(Optional.of(new UserId(UUID.fromString("22222222-2222-2222-2222-222222222222"))));
   }
 
   @Test

--- a/02-tramed-application-core/system-core/src/test/java/com/tramed/backend/applicationcore/systemcore/service/notification/NotificationServiceTest.java
+++ b/02-tramed-application-core/system-core/src/test/java/com/tramed/backend/applicationcore/systemcore/service/notification/NotificationServiceTest.java
@@ -46,7 +46,8 @@ class NotificationServiceTest {
         new NotificationService(notificationContentRepository, authenticatedUserProvider);
     lenient()
         .when(authenticatedUserProvider.getCurrentUserId())
-        .thenReturn(Optional.of(new UserId(UUID.fromString("22222222-2222-2222-2222-222222222222"))));
+        .thenReturn(
+            Optional.of(new UserId(UUID.fromString("22222222-2222-2222-2222-222222222222"))));
   }
 
   @Test

--- a/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/entity/user/UserEntity.java
+++ b/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/entity/user/UserEntity.java
@@ -7,10 +7,16 @@ import java.util.UUID;
 
 /** Entity representing an application user in the persistence layer. */
 public record UserEntity(
-    UUID userId, String username, String passwordHash, String fullName, boolean active, String role) {
+    UUID userId,
+    String username,
+    String passwordHash,
+    String fullName,
+    boolean active,
+    String role) {
 
   public User toDomain() {
-    return new User(new UserId(userId), username, passwordHash, fullName, active, UserRole.valueOf(role));
+    return new User(
+        new UserId(userId), username, passwordHash, fullName, active, UserRole.valueOf(role));
   }
 
   public static UserEntity fromDomain(User user) {

--- a/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/entity/user/UserEntity.java
+++ b/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/entity/user/UserEntity.java
@@ -1,0 +1,14 @@
+package com.tramed.backend.infrastructure.mybatis.entity.user;
+
+import com.tramed.backend.core.base.model.common.UserId;
+import com.tramed.backend.core.base.model.user.User;
+import java.util.UUID;
+
+/** Entity representing an application user in the persistence layer. */
+public record UserEntity(
+    UUID userId, String username, String passwordHash, String fullName, boolean active) {
+
+  public User toDomain() {
+    return new User(new UserId(userId), username, passwordHash, fullName, active);
+  }
+}

--- a/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/entity/user/UserEntity.java
+++ b/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/entity/user/UserEntity.java
@@ -2,13 +2,24 @@ package com.tramed.backend.infrastructure.mybatis.entity.user;
 
 import com.tramed.backend.core.base.model.common.UserId;
 import com.tramed.backend.core.base.model.user.User;
+import com.tramed.backend.core.base.model.user.UserRole;
 import java.util.UUID;
 
 /** Entity representing an application user in the persistence layer. */
 public record UserEntity(
-    UUID userId, String username, String passwordHash, String fullName, boolean active) {
+    UUID userId, String username, String passwordHash, String fullName, boolean active, String role) {
 
   public User toDomain() {
-    return new User(new UserId(userId), username, passwordHash, fullName, active);
+    return new User(new UserId(userId), username, passwordHash, fullName, active, UserRole.valueOf(role));
+  }
+
+  public static UserEntity fromDomain(User user) {
+    return new UserEntity(
+        user.userId().value(),
+        user.username(),
+        user.passwordHash(),
+        user.fullName(),
+        user.active(),
+        user.role().name());
   }
 }

--- a/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/mapper/UserMapper.java
+++ b/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/mapper/UserMapper.java
@@ -1,0 +1,11 @@
+package com.tramed.backend.infrastructure.mybatis.mapper;
+
+import com.tramed.backend.infrastructure.mybatis.entity.user.UserEntity;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface UserMapper {
+
+  UserEntity findByUsername(@Param("username") String username);
+}

--- a/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/mapper/UserMapper.java
+++ b/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.tramed.backend.infrastructure.mybatis.mapper;
 
 import com.tramed.backend.infrastructure.mybatis.entity.user.UserEntity;
+import java.util.UUID;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -8,4 +9,10 @@ import org.apache.ibatis.annotations.Param;
 public interface UserMapper {
 
   UserEntity findByUsername(@Param("username") String username);
+
+  UserEntity findById(@Param("userId") UUID userId);
+
+  void insert(@Param("user") UserEntity user);
+
+  void updateStatus(@Param("userId") UUID userId, @Param("active") boolean active);
 }

--- a/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/repository/UserRepository.java
+++ b/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.tramed.backend.infrastructure.mybatis.repository;
 
+import com.tramed.backend.core.base.model.common.UserId;
 import com.tramed.backend.core.base.model.user.User;
 import com.tramed.backend.infrastructure.mybatis.entity.user.UserEntity;
 import com.tramed.backend.infrastructure.mybatis.mapper.UserMapper;
@@ -16,5 +17,18 @@ public class UserRepository {
   public Optional<User> findByUsername(String username) {
     UserEntity entity = userMapper.findByUsername(username);
     return Optional.ofNullable(entity).map(UserEntity::toDomain);
+  }
+
+  public Optional<User> findById(UserId userId) {
+    UserEntity entity = userMapper.findById(userId.value());
+    return Optional.ofNullable(entity).map(UserEntity::toDomain);
+  }
+
+  public void insert(User user) {
+    userMapper.insert(UserEntity.fromDomain(user));
+  }
+
+  public void updateStatus(UserId userId, boolean active) {
+    userMapper.updateStatus(userId.value(), active);
   }
 }

--- a/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/repository/UserRepository.java
+++ b/03-tramed-infrastructure/mybatis/src/main/java/com/tramed/backend/infrastructure/mybatis/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.tramed.backend.infrastructure.mybatis.repository;
+
+import com.tramed.backend.core.base.model.user.User;
+import com.tramed.backend.infrastructure.mybatis.entity.user.UserEntity;
+import com.tramed.backend.infrastructure.mybatis.mapper.UserMapper;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepository {
+
+  private final UserMapper userMapper;
+
+  public Optional<User> findByUsername(String username) {
+    UserEntity entity = userMapper.findByUsername(username);
+    return Optional.ofNullable(entity).map(UserEntity::toDomain);
+  }
+}

--- a/03-tramed-infrastructure/mybatis/src/main/resources/mapper/UserMapper.xml
+++ b/03-tramed-infrastructure/mybatis/src/main/resources/mapper/UserMapper.xml
@@ -7,11 +7,52 @@
       username,
       password_hash,
       full_name,
-      active
+      active,
+      role
     FROM
       app_user
     WHERE
       username = #{username}
     LIMIT 1
   </select>
+
+  <select id="findById" resultType="com.tramed.backend.infrastructure.mybatis.entity.user.UserEntity">
+    SELECT
+      user_id,
+      username,
+      password_hash,
+      full_name,
+      active,
+      role
+    FROM
+      app_user
+    WHERE
+      user_id = #{userId}
+    LIMIT 1
+  </select>
+
+  <insert id="insert">
+    INSERT INTO app_user (
+      user_id,
+      username,
+      password_hash,
+      full_name,
+      active,
+      role
+    )
+    VALUES (
+      #{user.userId},
+      #{user.username},
+      #{user.passwordHash},
+      #{user.fullName},
+      #{user.active},
+      #{user.role}
+    )
+  </insert>
+
+  <update id="updateStatus">
+    UPDATE app_user
+    SET active = #{active}
+    WHERE user_id = #{userId}
+  </update>
 </mapper>

--- a/03-tramed-infrastructure/mybatis/src/main/resources/mapper/UserMapper.xml
+++ b/03-tramed-infrastructure/mybatis/src/main/resources/mapper/UserMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.tramed.backend.infrastructure.mybatis.mapper.UserMapper">
+  <select id="findByUsername" resultType="com.tramed.backend.infrastructure.mybatis.entity.user.UserEntity">
+    SELECT
+      user_id,
+      username,
+      password_hash,
+      full_name,
+      active
+    FROM
+      app_user
+    WHERE
+      username = #{username}
+    LIMIT 1
+  </select>
+</mapper>

--- a/03-tramed-infrastructure/mybatis/src/test/java/com/tramed/backend/infrastructure/mybatis/repository/NotificationContentRepositoryTest.java
+++ b/03-tramed-infrastructure/mybatis/src/test/java/com/tramed/backend/infrastructure/mybatis/repository/NotificationContentRepositoryTest.java
@@ -17,10 +17,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(properties = "spring.profiles.active=test")
-@ActiveProfiles("test")
 @DisplayName("NotificationContentRepository")
 public class NotificationContentRepositoryTest {
   @Autowired private NotificationContentRepository notificationContentRepository;

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ bootJar {
 	enabled = false
 }
 
-
 java {
 	sourceCompatibility = libs.versions.java.get()
 }

--- a/database/init.sql
+++ b/database/init.sql
@@ -28,11 +28,5 @@ CREATE TABLE IF NOT EXISTS notification_content (
                                                     CONSTRAINT fk_notification
                                                         FOREIGN KEY (notification_id)
                                                             REFERENCES notification (notification_id)
-                                                            ON DELETE CASCADE,
-                                                    CONSTRAINT fk_notification_created_by
-                                                        FOREIGN KEY (created_by)
-                                                            REFERENCES app_user (user_id),
-                                                    CONSTRAINT fk_notification_update_by
-                                                        FOREIGN KEY (update_by)
-                                                            REFERENCES app_user (user_id)
+                                                            ON DELETE CASCADE
 );

--- a/database/init.sql
+++ b/database/init.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS app_user (
                                         username VARCHAR(100) UNIQUE NOT NULL,
                                         password_hash VARCHAR(255) NOT NULL,
                                         full_name VARCHAR(255),
-                                        active BOOLEAN DEFAULT TRUE,
+                                        active BOOLEAN DEFAULT FALSE,
+                                        role VARCHAR(20) NOT NULL,
                                         created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/database/init.sql
+++ b/database/init.sql
@@ -1,3 +1,13 @@
+-- Tạo bảng app_user
+CREATE TABLE IF NOT EXISTS app_user (
+                                        user_id UUID PRIMARY KEY,
+                                        username VARCHAR(100) UNIQUE NOT NULL,
+                                        password_hash VARCHAR(255) NOT NULL,
+                                        full_name VARCHAR(255),
+                                        active BOOLEAN DEFAULT TRUE,
+                                        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Tạo bảng notification
 CREATE TABLE IF NOT EXISTS notification (
                                             notification_id UUID PRIMARY KEY,
@@ -17,5 +27,11 @@ CREATE TABLE IF NOT EXISTS notification_content (
                                                     CONSTRAINT fk_notification
                                                         FOREIGN KEY (notification_id)
                                                             REFERENCES notification (notification_id)
-                                                            ON DELETE CASCADE
+                                                            ON DELETE CASCADE,
+                                                    CONSTRAINT fk_notification_created_by
+                                                        FOREIGN KEY (created_by)
+                                                            REFERENCES app_user (user_id),
+                                                    CONSTRAINT fk_notification_update_by
+                                                        FOREIGN KEY (update_by)
+                                                            REFERENCES app_user (user_id)
 );

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -1,7 +1,7 @@
 -- Thêm dữ liệu mẫu vào bảng app_user
 INSERT INTO app_user (user_id, username, password_hash, full_name, active, role) VALUES
                                                                               ('22222222-2222-2222-2222-222222222222', 'admin',
-                                                                              '$2a$10$Dow1Ns/WSavwgJeayQM2jOB0ax3CjSxyxYh1SeDsICoZ6irMIXP3C', 'Administrator', true, 'ADMIN')
+                                                                              '$2b$10$GUBRNG.IvcSvCVWdt4bFDu4fLWkBpEDeH4LQFBZyGfli4OvpXR8CW', 'Administrator', true, 'ADMIN')
 ON CONFLICT (user_id) DO NOTHING;
 
 -- Thêm dữ liệu mẫu vào bảng notification

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -1,6 +1,7 @@
 -- Thêm dữ liệu mẫu vào bảng app_user
-INSERT INTO app_user (user_id, username, password_hash, full_name, active) VALUES
-                                                                              ('22222222-2222-2222-2222-222222222222', 'admin', '$2a$10$Dow1Ns/WSavwgJeayQM2jOB0ax3CjSxyxYh1SeDsICoZ6irMIXP3C', 'Administrator', true)
+INSERT INTO app_user (user_id, username, password_hash, full_name, active, role) VALUES
+                                                                              ('22222222-2222-2222-2222-222222222222', 'admin',
+                                                                              '$2a$10$Dow1Ns/WSavwgJeayQM2jOB0ax3CjSxyxYh1SeDsICoZ6irMIXP3C', 'Administrator', true, 'ADMIN')
 ON CONFLICT (user_id) DO NOTHING;
 
 -- Thêm dữ liệu mẫu vào bảng notification
@@ -19,3 +20,4 @@ INSERT INTO notification_content (notification_content_id, notification_id, cont
                                                                                                              ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '44444444-4444-4444-4444-444444444444', 'Bảo trì hệ thống', 'vi-VN', '22222222-2222-2222-2222-222222222222'),
                                                                                                              ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '44444444-4444-4444-4444-444444444444', 'System maintenance', 'en-US', '22222222-2222-2222-2222-222222222222')
 ON CONFLICT (notification_content_id) DO NOTHING;
+

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -1,3 +1,8 @@
+-- Thêm dữ liệu mẫu vào bảng app_user
+INSERT INTO app_user (user_id, username, password_hash, full_name, active) VALUES
+                                                                              ('22222222-2222-2222-2222-222222222222', 'admin', '$2a$10$Dow1Ns/WSavwgJeayQM2jOB0ax3CjSxyxYh1SeDsICoZ6irMIXP3C', 'Administrator', true)
+ON CONFLICT (user_id) DO NOTHING;
+
 -- Thêm dữ liệu mẫu vào bảng notification
 INSERT INTO notification (notification_id, logic_del_flg) VALUES
                                                            ('11111111-1111-1111-1111-111111111111', false),


### PR DESCRIPTION
## Summary
- require authentication for all endpoints by default while centralizing publicly accessible routes in a whitelist
- introduce a reusable BaseService that resolves the authenticated user and refactor NotificationService to use it
- allow the security configuration to permit all requests when the test profile is active so integration tests can run without JWT setup while supplying a fixed authenticated user in that profile

## Testing
- `./gradlew :01-tramed-presentation:web-api:spotlessApply`
- `./gradlew :02-tramed-application-core:system-core:test --tests NotificationServiceTest` *(fails: Maven Central returned HTTP 403 for JaCoCo artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68efb9b38aac832f8d966472d9747726