### PR TITLE
Secure Redis deployment with password support

### DIFF
--- a/01-tramed-presentation/web-api/build.gradle
+++ b/01-tramed-presentation/web-api/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation project(':02-tramed-application-core:system-core')
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/controller/auth/AuthenticationController.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/controller/auth/AuthenticationController.java
@@ -11,10 +11,15 @@ import com.tramed.backend.presentation.webapi.model.auth.RegisterResponse;
 import com.tramed.backend.presentation.webapi.model.auth.UpdateUserStatusRequest;
 import com.tramed.backend.presentation.webapi.security.jwt.JwtProperties;
 import com.tramed.backend.presentation.webapi.security.jwt.JwtTokenProvider;
+import com.tramed.backend.presentation.webapi.security.jwt.JwtTokenStore;
 import com.tramed.backend.presentation.webapi.security.user.ApplicationUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,6 +27,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,10 +40,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/tra-med-api/auth")
 public class AuthenticationController {
 
+  private static final String BEARER_PREFIX = "Bearer ";
+
   private final AuthenticationManager authenticationManager;
   private final JwtTokenProvider jwtTokenProvider;
   private final JwtProperties jwtProperties;
   private final UserService userService;
+  private final JwtTokenStore jwtTokenStore;
 
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
@@ -47,6 +56,7 @@ public class AuthenticationController {
               new UsernamePasswordAuthenticationToken(request.username(), request.password()));
       ApplicationUserDetails userDetails = (ApplicationUserDetails) authentication.getPrincipal();
       String token = jwtTokenProvider.generateToken(userDetails);
+      jwtTokenStore.store(token, Duration.ofMinutes(jwtProperties.expirationInMinutes()));
       return ResponseEntity.ok(
           new LoginResponse(
               token,
@@ -57,6 +67,13 @@ public class AuthenticationController {
     } catch (AuthenticationException ex) {
       throw new UnauthorizedException("E0005");
     }
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(HttpServletRequest request) {
+    extractToken(request).ifPresent(jwtTokenStore::remove);
+    SecurityContextHolder.clearContext();
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/register")
@@ -79,5 +96,13 @@ public class AuthenticationController {
       @PathVariable UUID userId, @RequestBody @Valid UpdateUserStatusRequest request) {
     userService.updateUserStatus(new UserId(userId), request.active());
     return ResponseEntity.noContent().build();
+  }
+
+  private Optional<String> extractToken(HttpServletRequest request) {
+    String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (header != null && header.startsWith(BEARER_PREFIX)) {
+      return Optional.of(header.substring(BEARER_PREFIX.length()));
+    }
+    return Optional.empty();
   }
 }

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtAuthenticationFilter.java
@@ -22,11 +22,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenProvider tokenProvider;
   private final ApplicationUserDetailsService userDetailsService;
+  private final JwtTokenStore tokenStore;
 
   public JwtAuthenticationFilter(
-      JwtTokenProvider tokenProvider, ApplicationUserDetailsService userDetailsService) {
+      JwtTokenProvider tokenProvider,
+      ApplicationUserDetailsService userDetailsService,
+      JwtTokenStore tokenStore) {
     this.tokenProvider = tokenProvider;
     this.userDetailsService = userDetailsService;
+    this.tokenStore = tokenStore;
   }
 
   @Override
@@ -40,6 +44,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             token -> {
               if (SecurityContextHolder.getContext().getAuthentication() == null) {
                 try {
+                  if (!tokenStore.exists(token)) {
+                    return;
+                  }
                   String username = tokenProvider.getUsernameFromToken(token);
                   var userDetails = userDetailsService.loadActiveUser(username);
                   if (tokenProvider.validateToken(token, userDetails)) {

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenStore.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenStore.java
@@ -1,0 +1,33 @@
+package com.tramed.backend.presentation.webapi.security.jwt;
+
+import java.time.Duration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenStore {
+
+  private static final String TOKEN_PREFIX = "auth:token:";
+
+  private final StringRedisTemplate redisTemplate;
+
+  public JwtTokenStore(StringRedisTemplate redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  public void store(String token, Duration ttl) {
+    redisTemplate.opsForValue().set(buildKey(token), token, ttl);
+  }
+
+  public boolean exists(String token) {
+    return Boolean.TRUE.equals(redisTemplate.hasKey(buildKey(token)));
+  }
+
+  public void remove(String token) {
+    redisTemplate.delete(buildKey(token));
+  }
+
+  private String buildKey(String token) {
+    return TOKEN_PREFIX + token;
+  }
+}

--- a/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenStore.java
+++ b/01-tramed-presentation/web-api/src/main/java/com/tramed/backend/presentation/webapi/security/jwt/JwtTokenStore.java
@@ -20,7 +20,7 @@ public class JwtTokenStore {
   }
 
   public boolean exists(String token) {
-    return Boolean.TRUE.equals(redisTemplate.hasKey(buildKey(token)));
+    return redisTemplate.hasKey(buildKey(token));
   }
 
   public void remove(String token) {

--- a/01-tramed-presentation/web-api/src/main/resources/application.properties
+++ b/01-tramed-presentation/web-api/src/main/resources/application.properties
@@ -1,2 +1,6 @@
 app.security.jwt.secret=VGhhbmhuYWRtaW5KV1RTZWNyZXRLRXkxMjM0NTY3ODkwMTIzNA==
 app.security.jwt.expiration-in-minutes=60
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.password=${REDIS_PASSWORD:tramed}
+spring.data.redis.timeout=2s

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ TraMed is a modular Spring Boot backend composed of shared core libraries, an ap
 
 ### Module layout
 - `00-tramed-core` – shared base abstractions and utilities that are reused by the rest of the codebase.
+- `01-tramed-presentation/web-api` – the Spring Boot application that wires the layers together and exposes HTTP endpoints.
 - `02-tramed-application-core` – application services and business logic.
 - `03-tramed-infrastructure` – infrastructure adapters such as MyBatis integrations.
-- `01-tramed-presentation/web-api` – the Spring Boot application that wires the layers together and exposes HTTP endpoints.
 
 ## Technologies
 - **Java 21** with the Gradle 8.13 toolchain.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# TraMed Backend
+
+## Overview
+TraMed is a modular Spring Boot backend composed of shared core libraries, an application layer, and a web API for exposing REST endpoints. The build is managed with Gradle and targets Java 21.
+
+### Module layout
+- `00-tramed-core` – shared base abstractions and utilities that are reused by the rest of the codebase.
+- `02-tramed-application-core` – application services and business logic.
+- `03-tramed-infrastructure` – infrastructure adapters such as MyBatis integrations.
+- `01-tramed-presentation/web-api` – the Spring Boot application that wires the layers together and exposes HTTP endpoints.
+
+## Technologies
+- **Java 21** with the Gradle 8.13 toolchain.
+- **Spring Boot 3.4.4** with starters for Web, Validation, Security, AOP, Data JPA, and Redis.
+- **JSON Web Token (jjwt)** for authentication tokens.
+- **PostgreSQL 16** as the relational database.
+- **Redis 7** as the token store for login sessions.
+- **Docker Compose** for local orchestration of PostgreSQL and Redis services.
+
+## Docker Compose setup
+The [`docker-compose.yaml`](./docker-compose.yaml) file defines two services for local development:
+
+| Service   | Description |
+|-----------|-------------|
+| `postgres` | Runs PostgreSQL 16 with a custom [`entrypoint.sh`](./entrypoint.sh) that keeps the standard `docker-entrypoint.sh` behavior while also executing the SQL initialization scripts described below. Data is persisted via the `postgres_data` named volume. |
+| `redis`    | Runs Redis 7 with append-only persistence enabled, secured by a password supplied through the `REDIS_PASSWORD` environment variable (defaults to `tramed`). Data is stored in the `redis_data` named volume. |
+
+Bring both services up with:
+
+```bash
+docker compose up -d
+```
+
+## Database initialization
+Two SQL scripts in the [`database`](./database) directory are automatically executed by the PostgreSQL container via the mounted entrypoint script:
+
+- [`init.sql`](./database/init.sql) – creates the schema, including the `app_user`, `notification`, and `notification_content` tables, along with their relationships.
+- [`seed.sql`](./database/seed.sql) – inserts sample records for an administrator account and several localized notification entries to support local testing.
+
+## Inspecting Redis data locally
+While the Docker Compose stack is running you can connect to the Redis container and inspect the in-memory data (e.g., active JWTs) with the Redis CLI:
+
+```bash
+docker exec -it redis_cache redis-cli -a tramed
+```
+
+Inside the shell you can run typical commands such as `KEYS *`, `GET <key>`, or `HGETALL <key>` to review the stored session tokens and other cached values.
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,5 +17,18 @@ services:
       - ./entrypoint.sh:/entrypoint.sh
     entrypoint: ["/entrypoint.sh"]
 
+  redis:
+    image: redis:7-alpine
+    container_name: redis_cache
+    restart: always
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-tramed}
+    command: ["sh", "-c", "redis-server --requirepass \"$REDIS_PASSWORD\" --appendonly yes"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
 volumes:
   postgres_data:
+  redis_data:


### PR DESCRIPTION
## Summary
- configure the docker-compose Redis service to enforce a password and persist data
- provide a matching default Redis password in the Spring configuration for local development

## Testing
- ./gradlew :01-tramed-presentation:web-api:test *(fails: HTTP 403 when downloading spring-boot-starter-data-redis from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68f25dea2fa8832fa7b65f9cc6185cc5